### PR TITLE
Vorschlag Wahlordnung

### DIFF
--- a/Metalab_wahlordnung.md
+++ b/Metalab_wahlordnung.md
@@ -3,6 +3,7 @@
 ## § 1: Gültigkeit
 
 (1) Diese Wahlordnung ist auf unbeschränkte Zeit gültig und bei allen Wahlen und Abstimmungen bei Generalversammlungen des Vereins anzuwenden.
+
 (2) Die Begriffe Wahl und Abstimmung werden in dieser Wahlordnung synonym verwendet.
 
 ## § 2: Änderungen und Abschaffung
@@ -12,20 +13,35 @@
 ## § 3: Abstimmungen
 
 (1) Zunächst wird eine erste Wahlrunde abgehalten, bei der alle Wahlberechtigten entweder mit "Ja" oder "Nein" abstimmen können. Enthaltungen sind möglich, werden aber nicht als gültige Stimmen im Sinne der Satzung gezählt.
+
 (2) Die Feststellung der einfachen bzw. qualifizierten Mehrheit im Sinne der Satzung erfolgt durch Division der Anzahl der "Ja"-Stimmen durch die Anzahl der "Ja"- und "Nein"-Stimmen.
+
 (3) Bei offener Abstimmung kann die Moderation bei klaren Mehrheitsverhältnissen auf das Auszählen der Stimmen verzichten und das Ergebnis direkt feststellen. Bei Unklarheiten muss auf Verlangen eines stimmberechtigten Mitgliedes eine Auszählung vorgenommen werden.
+
 (4) Bei geheimer Abstimmung kann die Moderation die Abstimmung über einzelne Punkte mit anderen Abstimmungen zeitlich und auf einem Stimmzettel zusammenfassen.
-(5) Bei geheimer Abstimmung von konkurrierenden Anträgen und Personenwahlen wird eine zweite Wahlrunde nach der Schulze-Methode abgehalten. Nur Anträge bzw. Kandidat*innen, die in der ersten Runde die erforderliche Mehrheit erreicht haben, nehmen an der zweiten Wahlrunde teil.
-(6) Jede*r Wahlberechtigte ordnet die Kandidat*innen nach seiner*ihrer Präferenz, wobei Nichtreihung zulässig ist (dies entspricht einer Gleichreihung auf den letzten Platz). Gleichreihung sollte zur Findung eines eindeutigen Ergebnisses möglichst vermieden werden; sollte jedoch ein Wahlzettel eine Gleichreihung enthalten, wird diese auch als solche gewertet.
-(7) Im Falle, dass die Schulze-Methode für eine Gruppe von Anträgen bzw. Kandidat*innen keine eindeutige Reihung ergibt, die Reihung der betroffenen Anträge bzw. Kandidat*innen aber für das Ergebnis relevant ist, so entscheidet zwischen den betroffenen Anträgen bzw. Kandidat*innen das Los.
-(8) Die erste und zweite Wahlrunde können durch die Moderation auf einem Stimmzettel zusammengefasst werden. In diesem Fall wird zunächst die erste Wahlrunde ausgezählt, um festzustellen, welche Kandidat*innen zur zweiten Wahlrunde zugelassen sind.
-(9) Hat nach der ersten Wahlrunde nur maximal ein Antrag bzw. die gewünschte Anzahl an Kandidat*innen die erforderliche Mehrheit erreicht, wird auf eine zweite Wahlrunde verzichtet. Wurden erste und zweite Wahlrunde auf einem Stimmzettel zusammengefasst, kann die Auszählung der zweiten Wahlrunde unterlassen werden.
+
+(5) Bei geheimer Abstimmung von konkurrierenden Anträgen und Personenwahlen wird eine zweite Wahlrunde nach der Schulze-Methode abgehalten. Nur Anträge bzw. Kandidat\*innen, die in der ersten Runde die erforderliche Mehrheit erreicht haben, nehmen an der zweiten Wahlrunde teil.
+
+(6) Jede\*r Wahlberechtigte ordnet die Kandidat\*innen nach seiner\*ihrer Präferenz, wobei Nichtreihung zulässig ist (dies entspricht einer Gleichreihung auf den letzten Platz). Gleichreihung sollte zur Findung eines eindeutigen Ergebnisses möglichst vermieden werden; sollte jedoch ein Wahlzettel eine Gleichreihung enthalten, wird diese auch als solche gewertet.
+
+(7) Der erstgereihte Antrag gilt als angenommen bzw. der\*die erstgereihte Kandidat\*in als gewählt. Ist die Wahl eines*r Stellvertreter\*in vorgesehen, so gilt für diese Position der*die zweitgereihte Kandidat\*in als gewählt. Nimmt ein*e Kandidat\*in die Wahl nicht an, wird diese*r von der Reihung gestrichen und der*die nächstgereihte Kandidat\*in gilt als gewählt, solange diese*r die benötigte Zustimmung zur Teilnahme an der zweiten Wahlrunde erhalten hat.
+
+(8) Im Falle, dass die Schulze-Methode für eine Gruppe von Anträgen bzw. Kandidat\*innen keine eindeutige Reihung ergibt, die Reihung der betroffenen Anträge bzw. Kandidat\*innen aber für das Ergebnis relevant ist, so entscheidet zwischen den betroffenen Anträgen bzw. Kandidat\*innen das Los.
+
+(9) Die erste und zweite Wahlrunde können durch die Moderation auf einem Stimmzettel zusammengefasst werden. In diesem Fall wird zunächst die erste Wahlrunde ausgezählt, um festzustellen, welche Kandidat\*innen zur zweiten Wahlrunde zugelassen sind.
+
+(10) Hat nach der ersten Wahlrunde nur maximal ein Antrag bzw. die gewünschte Anzahl an Kandidat\*innen die erforderliche Mehrheit erreicht, wird auf eine zweite Wahlrunde verzichtet. Wurden erste und zweite Wahlrunde auf einem Stimmzettel zusammengefasst, kann die Auszählung der zweiten Wahlrunde unterlassen werden.
 
 ## § 4: Auszählung
 
-(1) Auszählungen werden durch Wahlhelfer*innen durchgeführt. Diese werden zu Beginn der Generalversammlung durch einfache Mehrheit gewählt.
-(2) Die Auszählungen können computerunterstützt erfolgen. Dafür muss der Quellcode der hierzu verwendeten Programme spätestens mit dem Ende der Antragsfrist veröffentlicht werden. Die Eingabe der Wahlzettel erfolgt durch Wahlhelfer*innen mit gegenseitiger Fehlerkontrolle („Mehr-Augen-Prinzip“).
-(3) Auszählungen haben ansonsten per Hand durch die Wahlhelfer*innen zu erfolgen, welche im „Mehr-Augen-Prinzip“ Fehlervermeidung anstreben.
-(4) Die Wahlhelfer*innen sind rechtzeitig vor der Generalversammlung entsprechend in den relevanten Wahlsystemen zu schulen.
+(1) Auszählungen werden durch Wahlhelfer\*innen durchgeführt. Diese werden zu Beginn der Generalversammlung durch einfache Mehrheit gewählt.
+
+(2) Die Auszählungen können computerunterstützt erfolgen. Dafür muss der Quellcode der hierzu verwendeten Programme spätestens mit dem Ende der Antragsfrist veröffentlicht werden. Die Eingabe der Wahlzettel erfolgt durch Wahlhelfer\*innen mit gegenseitiger Fehlerkontrolle („Mehr-Augen-Prinzip“).
+
+(3) Auszählungen haben ansonsten per Hand durch die Wahlhelfer\*innen zu erfolgen, welche im „Mehr-Augen-Prinzip“ Fehlervermeidung anstreben.
+
+(4) Die Wahlhelfer\*innen sind rechtzeitig vor der Generalversammlung entsprechend in den relevanten Wahlsystemen zu schulen.
+
 (5) Bei Anwendung von computerunterstützten Auszählungen sind alle Wahlzettel nach der Wahl als Datensätze zu veröffentlichen, um die Wahl nachvollziehen zu können.
-(6) Die Wahlhelfer*innen teilen das Auszählungsergebnis unverzüglich der Moderation mit, welche die Beschlussfassung feststellt.
+
+(6) Die Wahlhelfer\*innen teilen das Auszählungsergebnis unverzüglich der Moderation mit, welche die Beschlussfassung feststellt.

--- a/Metalab_wahlordnung.md
+++ b/Metalab_wahlordnung.md
@@ -18,7 +18,7 @@
 
 (3) Bei offener Abstimmung kann die Moderation bei klaren Mehrheitsverhältnissen auf das Auszählen der Stimmen verzichten und das Ergebnis direkt feststellen. Bei Unklarheiten muss auf Verlangen eines stimmberechtigten Mitgliedes eine Auszählung vorgenommen werden.
 
-(4) Bei geheimer Abstimmung kann die Moderation die Abstimmung über einzelne Punkte mit anderen Abstimmungen zeitlich und auf einem Stimmzettel zusammenfassen.
+(4) Bei geheimer Abstimmung kann die Moderation die Abstimmung über einzelne Punkte mit anderen Abstimmungen zeitlich und auf einen Stimmzettel zusammenfassen.
 
 (5) Bei geheimer Abstimmung von konkurrierenden Anträgen und Personenwahlen wird eine zweite Wahlrunde nach der Schulze-Methode abgehalten. Nur Anträge bzw. Kandidat\*innen, die in der ersten Runde die erforderliche Mehrheit erreicht haben, nehmen an der zweiten Wahlrunde teil.
 

--- a/Metalab_wahlordnung.md
+++ b/Metalab_wahlordnung.md
@@ -11,19 +11,21 @@
 
 ## § 3: Abstimmungen
 
-(1) Zunächst wird eine erste Wahlrunde abgehalten, bei der alle Wahlberechtigten entweder mit "Ja" oder "Nein" abstimmen können. Enthaltungen werden nicht als gültige Stimmen im Sinne der Satzung gezählt.
+(1) Zunächst wird eine erste Wahlrunde abgehalten, bei der alle Wahlberechtigten entweder mit "Ja" oder "Nein" abstimmen können. Enthaltungen sind möglich, werden aber nicht als gültige Stimmen im Sinne der Satzung gezählt.
 (2) Die Feststellung der einfachen bzw. qualifizierten Mehrheit im Sinne der Satzung erfolgt durch Division der Anzahl der "Ja"-Stimmen durch die Anzahl der "Ja"- und "Nein"-Stimmen.
 (3) Bei offener Abstimmung kann die Moderation bei klaren Mehrheitsverhältnissen auf das Auszählen der Stimmen verzichten und das Ergebnis direkt feststellen. Bei Unklarheiten muss auf Verlangen eines stimmberechtigten Mitgliedes eine Auszählung vorgenommen werden.
-(4) Auf Verlangen eines stimmberechtigten Mitgliedes muss eine geheime Wahl mit Stimmzetteln vorgenommen werden. Die Moderation kann die Abstimmung über diesen Punkt mit anderen Abstimmungen zeitlich und auf einem Stimmzettel zusammenfassen.
-(5) Bei geheimer Abstimmung von konkurrierenden Anträgen und Personenwahlen wird eine zweite Wahlrunde nach der Schulze-Methode abgehalten. Nur Anträge bzw. Kandidat*innen, die in der ersten Runde eine einfache Mehrheit erreicht haben, nehmen an der zweiten Wahlrunde teil.
+(4) Bei geheimer Abstimmung kann die Moderation die Abstimmung über einzelne Punkte mit anderen Abstimmungen zeitlich und auf einem Stimmzettel zusammenfassen.
+(5) Bei geheimer Abstimmung von konkurrierenden Anträgen und Personenwahlen wird eine zweite Wahlrunde nach der Schulze-Methode abgehalten. Nur Anträge bzw. Kandidat*innen, die in der ersten Runde die erforderliche Mehrheit erreicht haben, nehmen an der zweiten Wahlrunde teil.
 (6) Jede*r Wahlberechtigte ordnet die Kandidat*innen nach seiner*ihrer Präferenz, wobei Nichtreihung zulässig ist (dies entspricht einer Gleichreihung auf den letzten Platz). Gleichreihung sollte zur Findung eines eindeutigen Ergebnisses möglichst vermieden werden; sollte jedoch ein Wahlzettel eine Gleichreihung enthalten, wird diese auch als solche gewertet.
 (7) Im Falle, dass die Schulze-Methode für eine Gruppe von Anträgen bzw. Kandidat*innen keine eindeutige Reihung ergibt, die Reihung der betroffenen Anträge bzw. Kandidat*innen aber für das Ergebnis relevant ist, so entscheidet zwischen den betroffenen Anträgen bzw. Kandidat*innen das Los.
 (8) Die erste und zweite Wahlrunde können durch die Moderation auf einem Stimmzettel zusammengefasst werden. In diesem Fall wird zunächst die erste Wahlrunde ausgezählt, um festzustellen, welche Kandidat*innen zur zweiten Wahlrunde zugelassen sind.
-(9) Werden erste und zweite Wahlrunde nicht zusammengefasst und hat nach der ersten Wahlrunde nur ein Antrag bzw. die gewünschte Anzahl an Kandidat*innen das benötigte Quorum erreicht, wird auf eine zweite Wahlrunde verzichtet.
+(9) Hat nach der ersten Wahlrunde nur maximal ein Antrag bzw. die gewünschte Anzahl an Kandidat*innen die erforderliche Mehrheit erreicht, wird auf eine zweite Wahlrunde verzichtet. Wurden erste und zweite Wahlrunde auf einem Stimmzettel zusammengefasst, kann die Auszählung der zweiten Wahlrunde unterlassen werden.
 
 ## § 4: Auszählung
 
-(1) Die Auszählungen können computerunterstützt erfolgen. Dafür muss der Quellcode der hierzu verwendeten Programme spätestens mit dem Ende der Antragsfrist veröffentlicht werden. Die Eingabe der Wahlzettel erfolgt durch Wahlhelfer*innen mit gegenseitiger Fehlerkontrolle („Mehr-Augen-Prinzip“).
-(2) Auszählungen haben ansonsten per Hand durch die Wahlhelfer*innen zu erfolgen, welche im „Mehr-Augen-Prinzip“ Fehlervermeidung anstreben.
-(3) Die Wahlhelfer*innen sind rechtzeitig vor der Generalversammlung entsprechend in den relevanten Wahlsystemen zu schulen.
-(4) Bei Anwendung von computerunterstützten Auszählungen sind alle Wahlzettel nach der Wahl als Datensätze zu veröffentlichen, um die Wahl nachvollziehen zu können.
+(1) Auszählungen werden durch Wahlhelfer*innen durchgeführt. Diese werden zu Beginn der Generalversammlung durch einfache Mehrheit gewählt.
+(2) Die Auszählungen können computerunterstützt erfolgen. Dafür muss der Quellcode der hierzu verwendeten Programme spätestens mit dem Ende der Antragsfrist veröffentlicht werden. Die Eingabe der Wahlzettel erfolgt durch Wahlhelfer*innen mit gegenseitiger Fehlerkontrolle („Mehr-Augen-Prinzip“).
+(3) Auszählungen haben ansonsten per Hand durch die Wahlhelfer*innen zu erfolgen, welche im „Mehr-Augen-Prinzip“ Fehlervermeidung anstreben.
+(4) Die Wahlhelfer*innen sind rechtzeitig vor der Generalversammlung entsprechend in den relevanten Wahlsystemen zu schulen.
+(5) Bei Anwendung von computerunterstützten Auszählungen sind alle Wahlzettel nach der Wahl als Datensätze zu veröffentlichen, um die Wahl nachvollziehen zu können.
+(6) Die Wahlhelfer*innen teilen das Auszählungsergebnis unverzüglich der Moderation mit, welche die Beschlussfassung feststellt.

--- a/Metalab_wahlordnung.md
+++ b/Metalab_wahlordnung.md
@@ -24,7 +24,7 @@
 
 (6) Jede\*r Wahlberechtigte ordnet die Kandidat\*innen nach seiner\*ihrer Präferenz, wobei Nichtreihung zulässig ist (dies entspricht einer Gleichreihung auf den letzten Platz). Gleichreihung sollte zur Findung eines eindeutigen Ergebnisses möglichst vermieden werden; sollte jedoch ein Wahlzettel eine Gleichreihung enthalten, wird diese auch als solche gewertet.
 
-(7) Der erstgereihte Antrag gilt als angenommen bzw. der\*die erstgereihte Kandidat\*in als gewählt. Ist die Wahl eines*r Stellvertreter\*in vorgesehen, so gilt für diese Position der*die zweitgereihte Kandidat\*in als gewählt. Nimmt ein*e Kandidat\*in die Wahl nicht an, wird diese*r von der Reihung gestrichen und der*die nächstgereihte Kandidat\*in gilt als gewählt, solange diese*r die benötigte Zustimmung zur Teilnahme an der zweiten Wahlrunde erhalten hat.
+(7) Der erstgereihte Antrag gilt als angenommen bzw. der\*die erstgereihte Kandidat\*in als gewählt. Ist die Wahl eines\*r Stellvertreter\*in vorgesehen, so gilt für diese Position der\*die zweitgereihte Kandidat\*in als gewählt. Nimmt ein\*e Kandidat\*in die Wahl nicht an, wird diese\*r von der Reihung gestrichen und der\*die nächstgereihte Kandidat\*in gilt als gewählt, solange diese\*r die benötigte Zustimmung zur Teilnahme an der zweiten Wahlrunde erhalten hat.
 
 (8) Im Falle, dass die Schulze-Methode für eine Gruppe von Anträgen bzw. Kandidat\*innen keine eindeutige Reihung ergibt, die Reihung der betroffenen Anträge bzw. Kandidat\*innen aber für das Ergebnis relevant ist, so entscheidet zwischen den betroffenen Anträgen bzw. Kandidat\*innen das Los.
 

--- a/Metalab_wahlordnung.md
+++ b/Metalab_wahlordnung.md
@@ -1,0 +1,29 @@
+# Wahlordnung des Vereins zur Förderung der Erforschung und Bildung sozialer und technischer Innovationen - „metalab“
+
+## § 1: Gültigkeit
+
+(1) Diese Wahlordnung ist auf unbeschränkte Zeit gültig und bei allen Wahlen und Abstimmungen bei Generalversammlungen des Vereins anzuwenden.
+(2) Die Begriffe Wahl und Abstimmung werden in dieser Wahlordnung synonym verwendet.
+
+## § 2: Änderungen und Abschaffung
+
+(1) Änderungen an dieser Wahlordnung inklusive der Abschaffung dieser Wahlordnung können durch die Generalversammlung durch einfache Mehrheit nach den Bestimmungen dieser Wahlordnung vorgenommen werden.
+
+## § 3: Abstimmungen
+
+(1) Zunächst wird eine erste Wahlrunde abgehalten, bei der alle Wahlberechtigten entweder mit "Ja" oder "Nein" abstimmen können. Enthaltungen werden nicht als gültige Stimmen im Sinne der Satzung gezählt.
+(2) Die Feststellung der einfachen bzw. qualifizierten Mehrheit im Sinne der Satzung erfolgt durch Division der Anzahl der "Ja"-Stimmen durch die Anzahl der "Ja"- und "Nein"-Stimmen.
+(3) Bei offener Abstimmung kann die Moderation bei klaren Mehrheitsverhältnissen auf das Auszählen der Stimmen verzichten und das Ergebnis direkt feststellen. Bei Unklarheiten muss auf Verlangen eines stimmberechtigten Mitgliedes eine Auszählung vorgenommen werden.
+(4) Auf Verlangen eines stimmberechtigten Mitgliedes muss eine geheime Wahl mit Stimmzetteln vorgenommen werden. Die Moderation kann die Abstimmung über diesen Punkt mit anderen Abstimmungen zeitlich und auf einem Stimmzettel zusammenfassen.
+(5) Bei geheimer Abstimmung von konkurrierenden Anträgen und Personenwahlen wird eine zweite Wahlrunde nach der Schulze-Methode abgehalten. Nur Anträge bzw. Kandidat*innen, die in der ersten Runde eine einfache Mehrheit erreicht haben, nehmen an der zweiten Wahlrunde teil.
+(6) Jede*r Wahlberechtigte ordnet die Kandidat*innen nach seiner*ihrer Präferenz, wobei Nichtreihung zulässig ist (dies entspricht einer Gleichreihung auf den letzten Platz). Gleichreihung sollte zur Findung eines eindeutigen Ergebnisses möglichst vermieden werden; sollte jedoch ein Wahlzettel eine Gleichreihung enthalten, wird diese auch als solche gewertet.
+(7) Im Falle, dass die Schulze-Methode für eine Gruppe von Anträgen bzw. Kandidat*innen keine eindeutige Reihung ergibt, die Reihung der betroffenen Anträge bzw. Kandidat*innen aber für das Ergebnis relevant ist, so entscheidet zwischen den betroffenen Anträgen bzw. Kandidat*innen das Los.
+(8) Die erste und zweite Wahlrunde können durch die Moderation auf einem Stimmzettel zusammengefasst werden. In diesem Fall wird zunächst die erste Wahlrunde ausgezählt, um festzustellen, welche Kandidat*innen zur zweiten Wahlrunde zugelassen sind.
+(9) Werden erste und zweite Wahlrunde nicht zusammengefasst und hat nach der ersten Wahlrunde nur ein Antrag bzw. die gewünschte Anzahl an Kandidat*innen das benötigte Quorum erreicht, wird auf eine zweite Wahlrunde verzichtet.
+
+## § 4: Auszählung
+
+(1) Die Auszählungen können computerunterstützt erfolgen. Dafür muss der Quellcode der hierzu verwendeten Programme spätestens mit dem Ende der Antragsfrist veröffentlicht werden. Die Eingabe der Wahlzettel erfolgt durch Wahlhelfer*innen mit gegenseitiger Fehlerkontrolle („Mehr-Augen-Prinzip“).
+(2) Auszählungen haben ansonsten per Hand durch die Wahlhelfer*innen zu erfolgen, welche im „Mehr-Augen-Prinzip“ Fehlervermeidung anstreben.
+(3) Die Wahlhelfer*innen sind rechtzeitig vor der Generalversammlung entsprechend in den relevanten Wahlsystemen zu schulen.
+(4) Bei Anwendung von computerunterstützten Auszählungen sind alle Wahlzettel nach der Wahl als Datensätze zu veröffentlichen, um die Wahl nachvollziehen zu können.


### PR DESCRIPTION
Falls #10 angenommen wird, kann die GV explizit eine Wahlordnung beschließen, wenn nicht, kann sie das implizit eh auch. Dies ist ein Vorschlag für beide Fälle und soll als sonstiger Antrag bei der nächsten GV abgestimmt werden.

tl;dr:
* Offene Abstimmung per Hand -> alles normal
* Wenn geheime Abstimmung über mehrere Anträge/Kandidat\*innen -> Zuerst Akzeptanzwahl (wollen wir den Antrag/die Person überhaupt, ja oder nein? Entscheidung per einfacher Mehrheit bzw. bei Statutenänderung 2/3), dann wenn noch immer mehrere Anträge/Kandidat*innen übrig sind Reihungswahl via [Schulze Methode](https://de.wikipedia.org/wiki/Schulze-Methode)
* Bei Anwendung der Schulze-Methode können Computer zur Berechnung des Ergebnisses verwendet werden, hilfreiche Tools: [[1]](http://www.public-software-group.org/preftools), [[2]](https://gruss.cc/schulze/index.php)
* Alle geheimen Wahlvorgänge können durch die Moderation zusammengefasst werden, damit nur einmal Stimmzetteln ausgeteilt werden müssen.
